### PR TITLE
[KEYCLOAK-14638] Deprecate Wildfly 19.1.0.Final and Wildfly Core 11.1.1.Final for adapter tests

### DIFF
--- a/testsuite/integration-arquillian/pom.xml
+++ b/testsuite/integration-arquillian/pom.xml
@@ -42,8 +42,8 @@
         <app.server>undertow</app.server>
 
         <!-- Wildfly deprecated versions -->
-        <wildfly.deprecated.version>18.0.1.Final</wildfly.deprecated.version>
-        <wildfly.deprecated.wildfly.core.version>10.0.3.Final</wildfly.deprecated.wildfly.core.version>
+        <wildfly.deprecated.version>19.1.0.Final</wildfly.deprecated.version>
+        <wildfly.deprecated.wildfly.core.version>11.1.1.Final</wildfly.deprecated.wildfly.core.version>
         <wildfly.deprecated.arquillian.wildfly.container>2.1.1.Final</wildfly.deprecated.arquillian.wildfly.container>
 
         <!--component versions-->


### PR DESCRIPTION
    [KEYCLOAK-14638] Deprecate Wildfly 19.1.0.Final and Wildfly Core 11.1.1.Final
    for adapter tests
    
    Note: Currently deprecated version of 'wildfly.deprecated.arquillian.wildfly.container'
    is still valid
    
    Signed-off-by: Jan Lieskovsky <jlieskov@redhat.com>



<!---
Please read https://github.com/keycloak/keycloak/blob/master/CONTRIBUTING.md and follow these guidelines when contributing to Keycloak
-->
